### PR TITLE
Regex filtering

### DIFF
--- a/script.js
+++ b/script.js
@@ -64,7 +64,7 @@
     const accounts = document.querySelectorAll('fieldset > div.saml-account');
     accounts.forEach((account) => {
       var name = account.querySelector('.saml-account-name').textContent;
-      if(-1 == name.indexOf(accountFilter)) {
+      if(null == name.match(accountFilter)) {
         account.style.display = 'none';
       } else {
         account.style.display = '';

--- a/script.js
+++ b/script.js
@@ -13,7 +13,7 @@
     const label = document.createElement('label');
     label.setAttribute('for', accountFilter);
     label.textContent = 'Account Filter: ';
-    
+
     input = document.createElement('input');
     input.type = 'text';
     input.name = 'accountFilter';
@@ -30,7 +30,7 @@
     div.appendChild(input);
     div.appendChild(submit);
 
-    header.insertAdjacentElement('afterend', div); 
+    header.insertAdjacentElement('afterend', div);
   }
 
   function onKeyUpHandler(event) {
@@ -49,7 +49,7 @@
     saved.innerHTML = '&#160;Saved';
     saved.style.color = 'green';
     event.target.insertAdjacentElement('afterend',saved);
-    setTimeout(() => {saved.remove()}, 2000);    
+    setTimeout(() => {saved.remove()}, 2000);
     return false;
   }
 


### PR DESCRIPTION
This PR enables regex matching for the filter.  Simple filters work like before, assuming your simple filters don't have magic regex characters.  Regex matching lets you do cool stuff like view all of your infra accounts and product dev accounts even if one is a prefix and the other a suffix, e.g. "infra-|-dev".